### PR TITLE
Upgrade to mongo docker image version 4.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,50 +3,50 @@ services:
 
   ## Config Servers
   config01:
-    image: mongo
-    command: mongod --port 27017 --configsvr --replSet configserver --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27017 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
   config02:
-    image: mongo
-    command: mongod --port 27017 --configsvr --replSet configserver --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27017 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
   config03:
-    image: mongo
-    command: mongod --port 27017 --configsvr --replSet configserver --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27017 --configsvr --replSet configserver --oplogSize 16
     volumes:
       - ./scripts:/scripts
 
   ## Shards
   shard01a:
-    image: mongo
-    command: mongod --port 27018 --shardsvr --replSet shard01 --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27018 --shardsvr --replSet shard01 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard01b:
-    image: mongo
-    command: mongod --port 27018 --shardsvr --replSet shard01 --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27018 --shardsvr --replSet shard01 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard02a:
-    image: mongo
-    command: mongod --port 27019 --shardsvr --replSet shard02 --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27019 --shardsvr --replSet shard02 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard02b:
     image: mongo
-    command: mongod --port 27019 --shardsvr --replSet shard02 --noprealloc --smallfiles --oplogSize 16
+    command: mongod --port 27019 --shardsvr --replSet shard02 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard03a:
-    image: mongo
-    command: mongod --port 27020 --shardsvr --replSet shard03 --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27020 --shardsvr --replSet shard03 --oplogSize 16
     volumes:
       - ./scripts:/scripts
   shard03b:
-    image: mongo
-    command: mongod --port 27020 --shardsvr --replSet shard03 --noprealloc --smallfiles --oplogSize 16
+    image: mongo:4.2.1
+    command: mongod --port 27020 --shardsvr --replSet shard03 --oplogSize 16
     volumes:
       - ./scripts:/scripts
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ Heavily inspired by [https://github.com/jfollenfant/mongodb-sharding-docker-comp
 * 1 Router (mongos): `router`
 * (TODO): DB data persistence using docker data volumes
 
+*all mongod/mongos instances are running mongodb version 4.2*
+
 ### First Run (initial setup)
 **Start all of the containers** (daemonized)
 


### PR DESCRIPTION
Upgrades and fixes the mongo docker image version to 4.2
Since MMapV1 is removed in 4.2, some mmap related configuration options are also removed.

Fixes: https://github.com/chefsplate/mongo-shard-docker-compose/issues/3 